### PR TITLE
Fix typo in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ zephyr_library_sources(
     src/lv_misc/lv_utils.c
 
     src/lv_font/lv_font.c
-    src/lv_font/lv_font_dejavu_16_persian_hebrew
+    src/lv_font/lv_font_dejavu_16_persian_hebrew.c
     src/lv_font/lv_font_fmt_txt.c
     src/lv_font/lv_font_loader.c
     src/lv_font/lv_font_montserrat_12.c


### PR DESCRIPTION
The source file `src/lv_font/lv_font_dejavu_16_persian_hebrew` does not exist causing errors when building. The file `src/lv_font/lv_font_dejavu_16_persian_hebrew.c` however does exist and is not referenced anywhere else. 
I assume this was simply a typo.