### PR TITLE
cmake: added missing file ext to lv_font_dejavu_16_persian_hebrew.c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ zephyr_library_sources(
     src/lv_misc/lv_utils.c
 
     src/lv_font/lv_font.c
-    src/lv_font/lv_font_dejavu_16_persian_hebrew
+    src/lv_font/lv_font_dejavu_16_persian_hebrew.c
     src/lv_font/lv_font_fmt_txt.c
     src/lv_font/lv_font_loader.c
     src/lv_font/lv_font_montserrat_12.c


### PR DESCRIPTION
In the CMakeLists.txt, the file lv_font_dejavu_16_persian_hebrew.c
was added without its .c extension, causing never CMakes ti fail
discovering the file.

This has been fixed by correctly add the file as:
lv_font_dejavu_16_persian_hebrew.c

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>