### PR TITLE
fix(zephyr): fix seek whence param parse result

### DIFF
--- a/zephyr/lvgl_fs.c
+++ b/zephyr/lvgl_fs.c
@@ -127,9 +127,22 @@ static lv_fs_res_t lvgl_fs_write(struct _lv_fs_drv_t *drv, void *file,
 static lv_fs_res_t lvgl_fs_seek(struct _lv_fs_drv_t *drv, void *file,
 				uint32_t pos, lv_fs_whence_t whence)
 {
-	int err;
+	int err, fs_whence;
 
-	err = fs_seek((struct fs_file_t *)file, pos, FS_SEEK_SET);
+	switch (whence) {
+	case LV_FS_SEEK_END:
+		fs_whence = FS_SEEK_END;
+		break;
+	case LV_FS_SEEK_CUR:
+		fs_whence = FS_SEEK_CUR;
+		break;
+	case LV_FS_SEEK_SET:
+	default:
+		fs_whence = FS_SEEK_SET;
+		break;
+	}
+
+	err = fs_seek((struct fs_file_t *)file, pos, fs_whence);
 	return errno_to_lv_fs_res(err);
 }
 


### PR DESCRIPTION
### Description of the feature or fix

In Zephyr os, the lvgl fs cannot seek the correct position when the `whence` is not `LV_FS_SEEK_SET`.

### Checkpoints
- [x] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [x] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [x] Update the documentation
