### PR TITLE
lvgl: kscan: set touch points within range

### DIFF
--- a/src/extra/libs/fsdrv/lv_fsdrv.h
+++ b/src/extra/libs/fsdrv/lv_fsdrv.h
@@ -28,19 +28,19 @@ extern "C" {
  **********************/
 
 #if LV_USE_FS_FATFS
-	void lv_fs_fatfs_init(void);
+void lv_fs_fatfs_init(void);
 #endif
 
 #if LV_USE_FS_STDIO
-	void lv_fs_stdio_init(void);
+void lv_fs_stdio_init(void);
 #endif
 
 #if LV_USE_FS_POSIX
-	void lv_fs_posix_init(void);
+void lv_fs_posix_init(void);
 #endif
 
 #if LV_USE_FS_WIN32
-	void lv_fs_win32_init(void);
+void lv_fs_win32_init(void);
 #endif
 
 /**********************

--- a/zephyr/lvgl.c
+++ b/zephyr/lvgl.c
@@ -271,6 +271,21 @@ static void lvgl_pointer_kscan_read(lv_indev_drv_t *drv, lv_indev_data_t *data)
 		prev.point.y = x;
 	}
 
+    /* filter readings within display */
+    if (prev.point.x <= 0) {
+        prev.point.x = 0;
+    }
+    else if (prev.point.x >= cap.x_resolution) {
+        prev.point.x = cap.x_resolution - 1;
+    }
+
+    if (prev.point.y <= 0) {
+        prev.point.y = 0;
+    }
+    else if (prev.point.y >= cap.y_resolution) {
+        prev.point.y = cap.y_resolution - 1;
+    }
+
 set_and_release:
 	*data = prev;
 


### PR DESCRIPTION
Check whether input points are outside of display and set to the maximum of the its axis.
Currently when an input device sends a point out of range, lvgl reports that it's outside of it.
I've implemented basic support for stmpe811 but the display readings are not 100% accurate.
So on the edges the point reported exceeds most of the times the actual display width and height.
That's a workaround avoiding implementation of input device calibration.
Maybe a calibration functionality could be implemented within kscan, rather than doing for each different input device driver?
