### PR TITLE
zephyr: demote error message to debug level

### DIFF
--- a/zephyr/lvgl.c
+++ b/zephyr/lvgl.c
@@ -198,7 +198,7 @@ static void lvgl_pointer_kscan_callback(const struct device *dev,
 	};
 
 	if (k_msgq_put(&kscan_msgq, &data, K_NO_WAIT) != 0) {
-		LOG_ERR("Could put input data into queue");
+		LOG_DBG("Could not put input data into queue");
 	}
 }
 


### PR DESCRIPTION
On some I2C controllers, when using gestures, we can get quite a number
of spurious events. Don't pollute the log unnecessarily especially as
this doesn't impact the functionality. Demote the error log to debug when
this happens and also correct the typo in the message itself (it should
say it: "Count *not* ...".