### PR TITLE
zephyr: migrate includes to <zephyr/...>

### DIFF
--- a/zephyr/lvgl.c
+++ b/zephyr/lvgl.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/init.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <lvgl.h>
 #include "lvgl_display.h"
 #ifdef CONFIG_LV_Z_USE_FILESYSTEM

--- a/zephyr/lvgl.c
+++ b/zephyr/lvgl.c
@@ -4,20 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <zephyr.h>
+#include <zephyr/init.h>
+#include <zephyr/zephyr.h>
 #include <lvgl.h>
 #include "lvgl_display.h"
 #ifdef CONFIG_LV_Z_USE_FILESYSTEM
 #include "lvgl_fs.h"
 #endif
 #ifdef CONFIG_LV_Z_POINTER_KSCAN
-#include <drivers/kscan.h>
+#include <zephyr/drivers/kscan.h>
 #endif
 #include LV_MEM_CUSTOM_INCLUDE
 
 #define LOG_LEVEL CONFIG_LV_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(lvgl);
 
 static lv_disp_drv_t disp_drv;

--- a/zephyr/lvgl_display.h
+++ b/zephyr/lvgl_display.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_LIB_GUI_LVGL_LVGL_DISPLAY_H_
 #define ZEPHYR_LIB_GUI_LVGL_LVGL_DISPLAY_H_
 
-#include <drivers/display.h>
+#include <zephyr/drivers/display.h>
 #include <lvgl.h>
 
 #ifdef __cplusplus

--- a/zephyr/lvgl_display_16bit.c
+++ b/zephyr/lvgl_display_16bit.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <lvgl.h>
 #include "lvgl_display.h"
 

--- a/zephyr/lvgl_display_16bit.c
+++ b/zephyr/lvgl_display_16bit.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <lvgl.h>
 #include "lvgl_display.h"
 

--- a/zephyr/lvgl_display_24bit.c
+++ b/zephyr/lvgl_display_24bit.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <lvgl.h>
 #include "lvgl_display.h"
 

--- a/zephyr/lvgl_display_24bit.c
+++ b/zephyr/lvgl_display_24bit.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <lvgl.h>
 #include "lvgl_display.h"
 

--- a/zephyr/lvgl_display_32bit.c
+++ b/zephyr/lvgl_display_32bit.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <lvgl.h>
 #include "lvgl_display.h"
 

--- a/zephyr/lvgl_display_32bit.c
+++ b/zephyr/lvgl_display_32bit.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <lvgl.h>
 #include "lvgl_display.h"
 

--- a/zephyr/lvgl_display_mono.c
+++ b/zephyr/lvgl_display_mono.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <lvgl.h>
 #include "lvgl_display.h"
 

--- a/zephyr/lvgl_display_mono.c
+++ b/zephyr/lvgl_display_mono.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <lvgl.h>
 #include "lvgl_display.h"
 

--- a/zephyr/lvgl_fs.c
+++ b/zephyr/lvgl_fs.c
@@ -5,7 +5,7 @@
  */
 
 #include <lvgl.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/fs/fs.h>
 #include <stdlib.h>
 #include "lvgl_fs.h"

--- a/zephyr/lvgl_fs.c
+++ b/zephyr/lvgl_fs.c
@@ -5,8 +5,8 @@
  */
 
 #include <lvgl.h>
-#include <zephyr.h>
-#include <fs/fs.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/fs/fs.h>
 #include <stdlib.h>
 #include "lvgl_fs.h"
 

--- a/zephyr/lvgl_mem.c
+++ b/zephyr/lvgl_mem.c
@@ -6,9 +6,9 @@
  */
 
 #include "lvgl_mem.h"
-#include <zephyr.h>
-#include <init.h>
-#include <sys/sys_heap.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/init.h>
+#include <zephyr/sys/sys_heap.h>
 
 
 #define HEAP_BYTES (CONFIG_LV_Z_MEM_POOL_MAX_SIZE * \

--- a/zephyr/lvgl_mem.c
+++ b/zephyr/lvgl_mem.c
@@ -6,7 +6,7 @@
  */
 
 #include "lvgl_mem.h"
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <zephyr/sys/sys_heap.h>
 

--- a/zephyr/lvgl_mem_kernel.c
+++ b/zephyr/lvgl_mem_kernel.c
@@ -5,8 +5,8 @@
  */
 
 #include "lvgl_mem.h"
-#include <zephyr.h>
-#include <init.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/init.h>
 
 K_HEAP_DEFINE(lvgl_mem_pool, CONFIG_LV_Z_MEM_POOL_MAX_SIZE *
 	      CONFIG_LV_Z_MEM_POOL_NUMBER_BLOCKS);

--- a/zephyr/lvgl_mem_kernel.c
+++ b/zephyr/lvgl_mem_kernel.c
@@ -5,7 +5,7 @@
  */
 
 #include "lvgl_mem.h"
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/init.h>
 
 K_HEAP_DEFINE(lvgl_mem_pool, CONFIG_LV_Z_MEM_POOL_MAX_SIZE *


### PR DESCRIPTION
Zephyr has prefixed all of its includes with <zephyr/...>. While the old
mode can still be used (CONFIG_LEGACY_INCLUDE_PATH) and is still enabled
by default, it's better to be prepared for its removal in the future.
