### PR TITLE
zephyr: prefix kernel include with <zephyr/...>

### DIFF
--- a/zephyr/lv_conf.h
+++ b/zephyr/lv_conf.h
@@ -31,7 +31,7 @@
 /* HAL settings */
 
 #define LV_TICK_CUSTOM			1
-#define LV_TICK_CUSTOM_INCLUDE		"kernel.h"
+#define LV_TICK_CUSTOM_INCLUDE		<zephyr/kernel.h>
 #define LV_TICK_CUSTOM_SYS_TIME_EXPR	(k_uptime_get_32())
 
 /* Misc settings */


### PR DESCRIPTION
LVGL could not be built with CONFIG_LEGACY_INCLUDE_PATH=n because the
Zephyr <kernel.h> include was not prefixed. Replaced "" with <> as it is
not a local include.
