### PR TITLE
zephyr: zephyr: Pick up keyboard scan from /chosen/zephyr,keyboard-scan

### DIFF
--- a/zephyr/Kconfig.input
+++ b/zephyr/Kconfig.input
@@ -12,12 +12,6 @@ config LV_Z_POINTER_KSCAN
 
 if LV_Z_POINTER_KSCAN
 
-config LV_Z_POINTER_KSCAN_DEV_NAME
-	string "Keyboard scan device name for pointer input"
-	default "KSCAN"
-	help
-	  Name of the keyboard scan device to use for pointer input.
-
 config LV_Z_POINTER_KSCAN_MSGQ_COUNT
 	int "Keyboard scan message queue count maximum"
 	default 10

--- a/zephyr/lvgl.c
+++ b/zephyr/lvgl.c
@@ -26,6 +26,7 @@ static lv_indev_drv_t indev_drv;
 #endif /* CONFIG_LV_Z_POINTER_KSCAN */
 
 #define DISPLAY_NODE DT_CHOSEN(zephyr_display)
+#define KSCAN_NODE DT_CHOSEN(zephyr_keyboard_scan)
 
 #ifdef CONFIG_LV_Z_BUFFER_ALLOC_STATIC
 
@@ -299,11 +300,10 @@ set_and_release:
 
 static int lvgl_pointer_kscan_init(void)
 {
-	const struct device *kscan_dev =
-		device_get_binding(CONFIG_LV_Z_POINTER_KSCAN_DEV_NAME);
+	const struct device *kscan_dev = DEVICE_DT_GET(KSCAN_NODE);
 
-	if (kscan_dev == NULL) {
-		LOG_ERR("Keyboard scan device not found.");
+	if (!device_is_ready(kscan_dev)) {
+		LOG_ERR("Keyboard scan device not ready.");
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
The LVGL binding currently uses a device name from Kconfig to discover
the kscan device. This is fragile and won't work well when removing labels.

Switch to using the /chosen/zephyr,keyboard-scan property instead. This
ensures that there is a compile-time error instead of a runtime error
if the keyboard scan device can't be found.

Signed-off-by: Kumar Gala <galak@kernel.org>

### Description of the feature or fix

A clear and concise description of what the bug or new feature is.

### Checkpoints
- [ ] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
