### PR TITLE
zephyr: add missing errno.h include

### DIFF
--- a/zephyr/lvgl_display.c
+++ b/zephyr/lvgl_display.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <errno.h>
+
 #include "lvgl_display.h"
 
 int set_lvgl_rendering_cb(lv_disp_drv_t *disp_drv)


### PR DESCRIPTION
lvgl_display.h was using errno.h definitions without including it.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
