### PR TITLE
fix(kconfig) Add back `LV_USE_THEME_MONO`.

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -856,6 +856,9 @@ menu "LVGL configuration"
         config LV_USE_THEME_BASIC
             bool "A very simple theme that is a good starting point for a custom theme"
             default y if !LV_CONF_MINIMAL
+        config LV_USE_THEME_MONO
+            bool "Mono theme"
+            default y if !LV_CONF_MINIMAL
     endmenu
 
     menu "Layouts"


### PR DESCRIPTION
`lv_theme_mono.c` wasn't selectable when using kconfig.
