### PR TITLE
zephyr: Ensure "released" event when no touches

### DIFF
--- a/zephyr/lvgl.c
+++ b/zephyr/lvgl.c
@@ -221,6 +221,7 @@ static void lvgl_pointer_kscan_read(lv_indev_drv_t *drv, lv_indev_data_t *data)
 	};
 
 	if (k_msgq_get(&kscan_msgq, &curr, K_NO_WAIT) != 0) {
+		prev.state = LV_INDEV_STATE_REL;
 		goto set_and_release;
 	}
 


### PR DESCRIPTION
If the Kscan driver only generates touch events,
we need to still report LV_INDEV_STATE_REL from the read callback when there are no events.

Signed-off-by: Seppo Takalo <seppo.takalo@nordicsemi.no>

### Description of the feature or fix

If the last reported event was "pressed", then the read callback would continue to report pressed event until there
is some other event coming. Nothing is ensuring a "released" event.

This is up to a discussion whether all Kscan drivers should ensure "released" or should this library do it.

### Checkpoints
- [X] Follow the [styling guide](https://github.com/lvgl/lvgl/blob/master/docs/CODING_STYLE.md)
- [ ] Run `code-format.py` from the `scripts` folder. [astyle](http://astyle.sourceforge.net/install.html) needs to be installed.
- [ ] Update the documentation
