### PR TITLE
Release fs file when closing it

### DIFF
--- a/zephyr/lvgl_fs.c
+++ b/zephyr/lvgl_fs.c
@@ -82,6 +82,7 @@ static lv_fs_res_t lvgl_fs_close(struct _lv_fs_drv_t *drv, void *file)
 	int err;
 
 	err = fs_close((struct fs_file_t *)file);
+	free(file);
 	return errno_to_lv_fs_res(err);
 }
 


### PR DESCRIPTION
A  _**fs_file_t**_ object is allocated when lvgl_fs_open() is called, but it is not released in lvgl_fs_close().
This commit fix it by adding free(file) in lvgl_fs_close().
