### PR TITLE
feature: lvgl performance tuning

### DIFF
--- a/zephyr/Kconfig.memory
+++ b/zephyr/Kconfig.memory
@@ -74,6 +74,15 @@ config LV_Z_FULL_REFRESH
 	  controllers that require a framebuffer to be present in system memory,
 	  since the controller can render the LVGL framebuffer directly
 
+config LV_Z_VDB_ALIGN
+	int "Rending buffer alignment"
+	default 4
+	depends on LV_Z_BUFFER_ALLOC_STATIC
+	help
+	  Rendering buffer alignment. Depending on chosen color depth,
+	  buffer may be accessed as a uint8_t *, uint16_t *, or uint32_t *,
+	  so buffer must be aligned to prevent unaligned memory access
+
 choice
 	prompt "Rendering Buffer Allocation"
 	default LV_Z_BUFFER_ALLOC_STATIC

--- a/zephyr/Kconfig.memory
+++ b/zephyr/Kconfig.memory
@@ -83,6 +83,14 @@ config LV_Z_VDB_ALIGN
 	  buffer may be accessed as a uint8_t *, uint16_t *, or uint32_t *,
 	  so buffer must be aligned to prevent unaligned memory access
 
+config LV_Z_VBD_CUSTOM_SECTION
+	bool "Link rendering buffers to custom section"
+	depends on LV_Z_BUFFER_ALLOC_STATIC
+	help
+	  Place LVGL rendering buffers in custom section, with tag ".lvgl_buf".
+	  This can be used by custom linker scripts to relocate the LVGL
+	  rendering buffers to a custom location, such as tightly coupled or
+	  external memory.
 choice
 	prompt "Rendering Buffer Allocation"
 	default LV_Z_BUFFER_ALLOC_STATIC

--- a/zephyr/Kconfig.memory
+++ b/zephyr/Kconfig.memory
@@ -66,6 +66,14 @@ config LV_Z_DOUBLE_VDB
 	help
 	  Use two buffers to render and flush data in parallel
 
+config LV_Z_FULL_REFRESH
+	bool "Force full refresh mode"
+	help
+	  Force full refresh of display on update. When combined with
+	  LV_Z_VDB_SIZE, this setting can improve performance for display
+	  controllers that require a framebuffer to be present in system memory,
+	  since the controller can render the LVGL framebuffer directly
+
 choice
 	prompt "Rendering Buffer Allocation"
 	default LV_Z_BUFFER_ALLOC_STATIC

--- a/zephyr/lvgl.c
+++ b/zephyr/lvgl.c
@@ -47,10 +47,19 @@ static lv_disp_draw_buf_t disp_buf;
  * uint16_t * or uint32_t *, therefore buffer needs to be aligned accordingly to
  * prevent unaligned memory accesses.
  */
-static uint8_t buf0[BUFFER_SIZE] __aligned(CONFIG_LV_Z_VDB_ALIGN);
-#ifdef CONFIG_LV_Z_DOUBLE_VDB
-static uint8_t buf1[BUFFER_SIZE] __aligned(CONFIG_LV_Z_VDB_ALIGN);
+static uint8_t buf0[BUFFER_SIZE]
+#ifdef CONFIG_LV_Z_VBD_CUSTOM_SECTION
+	Z_GENERIC_SECTION(.lvgl_buf)
 #endif
+	__aligned(CONFIG_LV_Z_VDB_ALIGN);
+
+#ifdef CONFIG_LV_Z_DOUBLE_VDB
+static uint8_t buf1[BUFFER_SIZE]
+#ifdef CONFIG_LV_Z_VBD_CUSTOM_SECTION
+	Z_GENERIC_SECTION(.lvgl_buf)
+#endif
+	__aligned(CONFIG_LV_Z_VDB_ALIGN);
+#endif /* CONFIG_LV_Z_DOUBLE_VDB */
 
 #endif /* CONFIG_LV_Z_BUFFER_ALLOC_STATIC */
 

--- a/zephyr/lvgl.c
+++ b/zephyr/lvgl.c
@@ -47,9 +47,9 @@ static lv_disp_draw_buf_t disp_buf;
  * uint16_t * or uint32_t *, therefore buffer needs to be aligned accordingly to
  * prevent unaligned memory accesses.
  */
-static uint8_t buf0[BUFFER_SIZE] __aligned(4);
+static uint8_t buf0[BUFFER_SIZE] __aligned(CONFIG_LV_Z_VDB_ALIGN);
 #ifdef CONFIG_LV_Z_DOUBLE_VDB
-static uint8_t buf1[BUFFER_SIZE] __aligned(4);
+static uint8_t buf1[BUFFER_SIZE] __aligned(CONFIG_LV_Z_VDB_ALIGN);
 #endif
 
 #endif /* CONFIG_LV_Z_BUFFER_ALLOC_STATIC */

--- a/zephyr/lvgl.c
+++ b/zephyr/lvgl.c
@@ -353,6 +353,10 @@ static int lvgl_init(void)
 	lv_disp_drv_init(&disp_drv);
 	disp_drv.user_data = (void *)&disp_data;
 
+#ifdef CONFIG_LV_Z_FULL_REFRESH
+	disp_drv.full_refresh = 1;
+#endif
+
 	err = lvgl_allocate_rendering_buffers(&disp_drv);
 	if (err != 0) {
 		return err;


### PR DESCRIPTION
### Description of the feature or fix

This PR introduces several performance tuning settings for the Zephyr LVGL port:
- Enable setting the `full_refresh` bit, which configures LVGL to only call `display_write` with a buffer equivalent in size to the display. This improves performance for display controllers that render from a framebuffer in memory significantly, since they no longer have to copy the framebuffer passed into `display_write` into a driver allocated framebuffer
- Enable setting LVGL rendering buffer alignment. This is required because some display hardware has more restrictive alignment requirements on input buffers than the default value of 4 bytes.
- Allow placing LVGL rendering buffers into a custom section. This allows applications to relocate LVGL buffers to a custom location (such as external RAM)