### PR TITLE
zephyr: prefix `autoconf.h` with `zephyr/`

### DIFF
--- a/env_support/cmake/zephyr.cmake
+++ b/env_support/cmake/zephyr.cmake
@@ -4,7 +4,7 @@ if(CONFIG_LVGL)
 
   target_include_directories(lvgl INTERFACE ${LVGL_ROOT_DIR})
 
-  zephyr_compile_definitions(LV_CONF_KCONFIG_EXTERNAL_INCLUDE=<autoconf.h>)
+  zephyr_compile_definitions(LV_CONF_KCONFIG_EXTERNAL_INCLUDE=<zephyr/autoconf.h>)
 
   zephyr_library()
 


### PR DESCRIPTION
Update the include path of `autoconf.h` to `zephyr/autoconf.h`

See https://github.com/zephyrproject-rtos/zephyr/pull/63973
