### PR TITLE
Prevent OOB reads in lv_txt_utf8_next

### DIFF
--- a/src/misc/lv_txt.c
+++ b/src/misc/lv_txt.c
@@ -604,6 +604,9 @@ static uint32_t lv_txt_utf8_next(const char * txt, uint32_t * i)
     uint32_t i_tmp = 0;
     if(i == NULL) i = &i_tmp;
 
+    /* Ensure the string is not null */
+    if (txt == NULL || txt[*i] == '\0') return result;
+
     /*Normal ASCII*/
     if(LV_IS_ASCII(txt[*i])) {
         result = txt[*i];


### PR DESCRIPTION
### Description

The root cause of the bug is the assumption that the pointer `*i` always refers to a valid position within the null-terminated string `txt`. However, in cases where `*i` exceeds the string bounds or encounters a null terminator unexpectedly, the code performs invalid memory accesses.
