### PR TITLE
Fix unused function warning

### DIFF
--- a/src/draw/lv_draw.c
+++ b/src/draw/lv_draw.c
@@ -34,10 +34,12 @@
 static bool is_independent(lv_layer_t * layer, lv_draw_task_t * t_check);
 static void lv_cleanup_task(lv_draw_task_t * t, lv_display_t * disp);
 
+#if LV_LOG_LEVEL <= LV_LOG_LEVEL_INFO
 static inline uint32_t get_layer_size_kb(uint32_t size_byte)
 {
     return (size_byte + 1023) >> 10;
 }
+#endif
 
 /**********************
  *  STATIC VARIABLES


### PR DESCRIPTION
Fix unused function warning.

Cherry-picked from upstream commit https://github.com/lvgl/lvgl/commit/c8c87d46fc1ee32731f5879c321baa692dab614e.

This will allow https://github.com/zephyrproject-rtos/zephyr/pull/83830 to proceed.