### PR TITLE
fix(config): add generic ARM Cortex-M flag

### DIFF
--- a/src/draw/renesas/dave2d/lv_draw_dave2d.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d.c
@@ -34,7 +34,7 @@
  **********************/
 
 static void execute_drawing(lv_draw_dave2d_unit_t * u);
-#if defined(RENESAS_CORTEX_M85) || defined(_RENESAS_RZA_)
+#if defined(ARM_CORTEX_M55_M85) || defined(RENESAS_CORTEX_M85) || defined(_RENESAS_RZA_)
     #if (BSP_CFG_DCACHE_ENABLED) || defined(_RENESAS_RZA_)
         static void _dave2d_buf_invalidate_cache_cb(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
     #endif
@@ -116,7 +116,7 @@ void lv_draw_dave2d_init(void)
 static void lv_draw_buf_dave2d_init_handlers(void)
 {
 
-#if defined(RENESAS_CORTEX_M85) || defined(_RENESAS_RZA_)
+#if defined(ARM_CORTEX_M55_M85) || defined(RENESAS_CORTEX_M85) || defined(_RENESAS_RZA_)
 #if (BSP_CFG_DCACHE_ENABLED) || defined(_RENESAS_RZA_)
     lv_draw_buf_handlers_t * handlers = lv_draw_buf_get_handlers();
     handlers->invalidate_cache_cb = _dave2d_buf_invalidate_cache_cb;
@@ -124,7 +124,7 @@ static void lv_draw_buf_dave2d_init_handlers(void)
 #endif
 }
 
-#if defined(RENESAS_CORTEX_M85) || defined(_RENESAS_RZA_)
+#if defined(ARM_CORTEX_M55_M85) || defined(RENESAS_CORTEX_M85) || defined(_RENESAS_RZA_)
 #if (BSP_CFG_DCACHE_ENABLED) || defined(_RENESAS_RZA_)
 static void _dave2d_buf_invalidate_cache_cb(const lv_draw_buf_t * draw_buf, const lv_area_t * area)
 {
@@ -143,7 +143,7 @@ static void _dave2d_buf_invalidate_cache_cb(const lv_draw_buf_t * draw_buf, cons
     address = address + (area->x1 * (int32_t)bytes_per_pixel) + (stride * (uint32_t)area->y1);
 
     for(i = 0; i < lines; i++) {
-#if defined(RENESAS_CORTEX_M85)
+#if defined(ARM_CORTEX_M55_M85) || defined(RENESAS_CORTEX_M85)
         SCB_CleanInvalidateDCache_by_Addr(address, bytes_to_flush_per_line);
 #else /* _RENESAS_RZA_ */
         R_BSP_CACHE_CleanInvalidateRange((uint64_t) address, (uint64_t) bytes_to_flush_per_line);
@@ -480,7 +480,7 @@ static void execute_drawing(lv_draw_dave2d_unit_t * u)
     /* remember draw unit for access to unit's context */
     t->draw_unit = (lv_draw_unit_t *)u;
 
-#if defined(RENESAS_CORTEX_M85) || defined(_RENESAS_RZA_)
+#if defined(ARM_CORTEX_M55_M85) || defined(RENESAS_CORTEX_M85) || defined(_RENESAS_RZA_)
 #if (BSP_CFG_DCACHE_ENABLED) || defined(_RENESAS_RZA_)
     lv_layer_t * layer = t->target_layer;
     lv_area_t clipped_area;
@@ -539,7 +539,7 @@ static void execute_drawing(lv_draw_dave2d_unit_t * u)
             break;
     }
 
-#if defined(RENESAS_CORTEX_M85) || defined(_RENESAS_RZA_)
+#if defined(ARM_CORTEX_M55_M85) || defined(RENESAS_CORTEX_M85) || defined(_RENESAS_RZA_)
 #if (BSP_CFG_DCACHE_ENABLED) || defined(_RENESAS_RZA_)
     lv_draw_buf_invalidate_cache(layer->draw_buf, &clipped_area);
 #endif

--- a/src/draw/renesas/dave2d/lv_draw_dave2d_image.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d_image.c
@@ -115,7 +115,7 @@ static void img_draw_core(lv_draw_task_t * t, const lv_draw_image_dsc_t * draw_d
     src_blend_mode    = d2_getblendmodesrc(u->d2_handle);
     dst_blend_mode    = d2_getblendmodedst(u->d2_handle);
 
-#if defined(RENESAS_CORTEX_M85) || defined(_RENESAS_RZA_)
+#if defined(ARM_CORTEX_M55_M85) || defined(RENESAS_CORTEX_M85) || defined(_RENESAS_RZA_)
 #if (BSP_CFG_DCACHE_ENABLED) || defined(_RENESAS_RZA_)
     d1_cacheblockflush(u->d2_handle, 0, src_buf,
                        img_stride * header->h); //Stride is in bytes, not pixels/texels

--- a/src/draw/renesas/dave2d/lv_draw_dave2d_label.c
+++ b/src/draw/renesas/dave2d/lv_draw_dave2d_label.c
@@ -88,7 +88,7 @@ static void lv_draw_dave2d_draw_letter_cb(lv_draw_task_t * t, lv_draw_glyph_dsc_
 
                     const lv_draw_buf_t * draw_buf = glyph_draw_dsc->glyph_data;
 
-#if defined(RENESAS_CORTEX_M85) || defined(_RENESAS_RZA_)
+#if defined(ARM_CORTEX_M55_M85) || defined(RENESAS_CORTEX_M85) || defined(_RENESAS_RZA_)
 #if (BSP_CFG_DCACHE_ENABLED) || defined(_RENESAS_RZA_)
                     d1_cacheblockflush(unit->d2_handle, 0, draw_buf->data, draw_buf->data_size);
 #endif

--- a/src/drivers/display/renesas_glcdc/lv_renesas_glcdc.c
+++ b/src/drivers/display/renesas_glcdc/lv_renesas_glcdc.c
@@ -246,7 +246,7 @@ static void flush_direct(lv_display_t * display, const lv_area_t * area, uint8_t
 
     if(!lv_display_flush_is_last(display)) return;
 
-#if defined(RENESAS_CORTEX_M85) && (BSP_CFG_DCACHE_ENABLED)
+#if (defined(ARM_CORTEX_M55_M85) || defined(RENESAS_CORTEX_M85)) && (BSP_CFG_DCACHE_ENABLED)
     /* Invalidate cache - so the HW can access any data written by the CPU */
     SCB_CleanInvalidateDCache_by_Addr(px_map, sizeof(fb_background[0]));
 #endif
@@ -325,7 +325,7 @@ static void flush_partial(lv_display_t * display, const lv_area_t * area, uint8_
     for(i = 0; i < h; i++) {
         lv_memcpy(fb, img, w * BYTES_PER_PIXEL);
 
-#if defined(RENESAS_CORTEX_M85) && (BSP_CFG_DCACHE_ENABLED)
+#if (defined(ARM_CORTEX_M55_M85) || defined(RENESAS_CORTEX_M85)) && (BSP_CFG_DCACHE_ENABLED)
         SCB_CleanInvalidateDCache_by_Addr(fb, w * BYTES_PER_PIXEL);
 #endif
         fb += DISPLAY_HSIZE_INPUT0;


### PR DESCRIPTION
Add generic ARM Cortex-M55 and -M85 support to avoid RENESAS_CORTEX_M85 usage for cache control.
