### PR TITLE
fix(ppa): drop unused image descriptor declaration

### DIFF
--- a/src/draw/espressif/ppa/lv_draw_ppa_img.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa_img.c
@@ -54,8 +54,6 @@ static void lv_draw_img_ppa_core(lv_draw_task_t * t, const lv_draw_image_dsc_t *
     lv_color_format_t dest_cf = draw_buf->header.cf;
     uint8_t * dest_buf = draw_buf->data;
 
-    extern const lv_image_dsc_t img_benchmark_lvgl_logo_rgb;
-
     ppa_blend_oper_config_t cfg = {
         .in_bg = {
             .buffer          = (void *)src_buf,


### PR DESCRIPTION
The image blit path declares an extern benchmark image descriptor that nothing in the function references, which warns under -Wunused-variable. Remove the leftover declaration.

