### PR TITLE
fix(ppa): correct cache maintenance and blend geometry

### DIFF
--- a/src/draw/espressif/ppa/lv_draw_ppa.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa.c
@@ -122,6 +122,9 @@ static int32_t ppa_evaluate(lv_draw_unit_t * u, lv_draw_task_t * t)
                      && dsc->scale_y == 256
                      && dsc->rotation == 0
                      && lv_image_src_get_type(dsc->src) == LV_IMAGE_SRC_VARIABLE
+                     /* The engine can only express a stride of whole pixels */
+                     && (dsc->header.stride %
+                         lv_color_format_get_size(dsc->header.cf)) == 0
                      && (dsc->header.cf == LV_COLOR_FORMAT_RGB888
                          || dsc->header.cf == LV_COLOR_FORMAT_RGB565)
                      && (dsc->base.layer->color_format == LV_COLOR_FORMAT_RGB888

--- a/src/draw/espressif/ppa/lv_draw_ppa_buf.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa_buf.c
@@ -41,6 +41,11 @@ void lv_draw_buf_ppa_init_handlers(void)
 
 static void invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area)
 {
-    esp_cache_msync(draw_buf->data, draw_buf->data_size, ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA);
+    LV_UNUSED(area);
+
+    /* Write back what the CPU rendered and drop the lines the engine wrote */
+    esp_cache_msync(draw_buf->data, draw_buf->data_size,
+                    ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA |
+                    ESP_CACHE_MSYNC_FLAG_INVALIDATE);
 }
 #endif /* LV_USE_PPA */

--- a/src/draw/espressif/ppa/lv_draw_ppa_img.c
+++ b/src/draw/espressif/ppa/lv_draw_ppa_img.c
@@ -54,12 +54,11 @@ static void lv_draw_img_ppa_core(lv_draw_task_t * t, const lv_draw_image_dsc_t *
     lv_color_format_t dest_cf = draw_buf->header.cf;
     uint8_t * dest_buf = draw_buf->data;
 
-    extern const lv_image_dsc_t img_benchmark_lvgl_logo_rgb;
-
     ppa_blend_oper_config_t cfg = {
         .in_bg = {
             .buffer          = (void *)src_buf,
-            .pic_w           = draw_dsc->header.w,
+            /* pic_w sets the pitch the engine walks, so it follows the stride */
+            .pic_w           = draw_dsc->header.stride / lv_color_format_get_size(src_cf),
             .pic_h           = draw_dsc->header.h,
             .block_w         = lv_area_get_width(clipped_img_area),
             .block_h         = lv_area_get_height(clipped_img_area),
@@ -72,15 +71,16 @@ static void lv_draw_img_ppa_core(lv_draw_task_t * t, const lv_draw_image_dsc_t *
         .bg_alpha_update_mode  = PPA_ALPHA_FIX_VALUE,
         .bg_alpha_fix_val      = 0xFF,
         .bg_ck_en              = false,
+        /* The foreground is the destination surface, described with its own geometry */
         .in_fg = {
             .buffer          = (void *)dest_buf,
-            .pic_w           = draw_dsc->header.w,
-            .pic_h           = draw_dsc->header.h,
+            .pic_w           = draw_buf->header.stride / lv_color_format_get_size(dest_cf),
+            .pic_h           = draw_buf->header.h,
             .block_w         = lv_area_get_width(clipped_img_area),
             .block_h         = lv_area_get_height(clipped_img_area),
-            .block_offset_x  = src_area.x1,
-            .block_offset_y  = src_area.y1,
-            .blend_cm        = PPA_BLEND_COLOR_MODE_A8,
+            .block_offset_x  = dest_area.x1,
+            .block_offset_y  = dest_area.y1,
+            .blend_cm        = lv_color_format_to_ppa_blend(dest_cf),
         },
         .fg_fix_rgb_val = {
             .r = 0,
@@ -89,13 +89,14 @@ static void lv_draw_img_ppa_core(lv_draw_task_t * t, const lv_draw_image_dsc_t *
         },
         .fg_rgb_swap           = false,
         .fg_byte_swap          = false,
+        /* The image is opaque: hold the destination transparent so the source shows */
         .fg_alpha_update_mode  = PPA_ALPHA_FIX_VALUE,
         .fg_alpha_fix_val      = 0,
         .fg_ck_en              = false,
         .out = {
             .buffer          = dest_buf,
             .buffer_size     = draw_buf->data_size,
-            .pic_w           = draw_buf->header.w,
+            .pic_w           = draw_buf->header.stride / lv_color_format_get_size(dest_cf),
             .pic_h           = draw_buf->header.h,
             .block_offset_x  = dest_area.x1,
             .block_offset_y  = dest_area.y1,


### PR DESCRIPTION
Two fixes to the Espressif PPA draw unit:

- `invalidate_cache()` only wrote back, leaving the CPU with stale lines
  for regions the PPA had written. Added
  `ESP_CACHE_MSYNC_FLAG_INVALIDATE` so the pass writes back and
  invalidates.

- The image path passed the picture width as `pic_w`, but that field
  sets the pitch the engine walks. It now derives from the stride, and
  images whose stride is not a whole number of pixels are skipped. The
  foreground descriptor also now uses the destination's geometry and
  colour format instead of the source's.

Tested on ESP32-P4 with a 1024x600 RGB888 MIPI-DSI panel running
`demos/benchmark`. All 16 scenes render correctly; scenes 1, 3, 4, 5
and 16 were corrupted before.